### PR TITLE
tests use testify; "stop" channel uses empty struct;

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ There are two types you can use: `Streamer` and `MultiStreamer`.
 ### Streamer
 
 A `Streamer` is a single worker which reads rows, queues them, and inserts them
-(also called "flushing") in bulk into BigQuery once a certain threshold is reached.
+(also called *flushing*) in bulk into BigQuery once a certain threshold is reached.
 Thresholds can be either an amount of rows queued, or based on time - inserting once a certain time has passed.
 
 This provides flush control, inserting in set sizes and quickly enough.
 Please note Google has [quota policies on size and frequency of inserts][quota policy].
 
-In addition, the Streamer knows to handle BigQuery server erros (HTTP 500 and the like),
+In addition, the Streamer knows how to handle BigQuery server errors (HTTP 500 and the like),
 and attempts to retry insertions several times on such failures.
 
 It also sends errors on an error channel, which can be read an handled.
@@ -65,17 +65,23 @@ $ ./multi_integration_test.sh
 
 [godoc]: https://godoc.org/github.com/rounds/go-bqstreamer
 [godoc image]: https://godoc.org/github.com/rounds/go-bqstreamer?status.svg
+
 [travis image]: https://travis-ci.org/rounds/go-bqstreamer.svg
 [travis]: https://travis-ci.org/rounds/go-bqstreamer
+
 [coveralls image]: https://coveralls.io/repos/rounds/go-bqstreamer/badge.svg
 [coveralls]: https://coveralls.io/r/rounds/go-bqstreamer
+
 [stream insert]: https://cloud.google.com/bigquery/streaming-data-into-bigquery
 [bigquery]: https://cloud.google.com/bigquery/
+[quota policy]: https://cloud.google.com/bigquery/streaming-data-into-bigquery#quota
+[credentials]: https://cloud.google.com/bigquery/authorization
+
 [rounds]: http://rounds.com/
 [blog post]: http://rounds.com/blog/collecting-user-data-and-usage/
+[issues]: https://github.com/rounds/go-bqstreamer/issues
+
 [gvm]: https://github.com/moovweb/gvm
-[credentials]: https://cloud.google.com/bigquery/authorization
+
 [multi-streamer example]: multi_streamer_example_test.go
 [streamer example]: streamer_example_test.go
-[quota policy]: https://cloud.google.com/bigquery/streaming-data-into-bigquery#quota
-[issues]: https://github.com/rounds/go-bqstreamer/issues

--- a/multi_streamer_integration_test.go
+++ b/multi_streamer_integration_test.go
@@ -5,10 +5,14 @@ package bqstreamer
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/jwt"
 	bigquery "google.golang.org/api/bigquery/v2"
 )
 
@@ -18,7 +22,41 @@ var (
 	datasetID = flag.String("dataset", "", "bigquery dataset id")
 	tableID   = flag.String("table", "", "bigquery table id")
 	jsonPath  = flag.String("json", "bigquery_streamer_integration.json", "json file path to be inserted into bigquery")
+
+	jwtConfig *jwt.Config
 )
+
+func init() {
+	flag.Parse()
+
+	// Validate custom parameters.
+	crash := true
+SANITY:
+	switch {
+	case *keyPath == "":
+		fmt.Println("missing key parameter")
+	case *projectID == "":
+		fmt.Println("missing project parameter")
+	case *datasetID == "":
+		fmt.Println("missing dataset parameter")
+	case *tableID == "":
+		fmt.Println("missing table parameter")
+	case *jsonPath == "":
+		fmt.Println("missing json parameter")
+	default:
+		var err error
+		if jwtConfig, err = NewJWTConfig(*keyPath); err != nil {
+			fmt.Println(err)
+			break SANITY
+		}
+		return
+	}
+
+	if crash {
+		flag.Usage()
+		os.Exit(2)
+	}
+}
 
 // TestMultiStreamerInsertTableToBigQuery test stream inserting a row (given as argument)
 // 5 times to BigQuery using a multi-streamer, and logs the response.
@@ -27,48 +65,23 @@ var (
 //
 // Usage: 'go test -v -tags=integration-multi-streamer -key /path/to/key.json -project projectID -dataset datasetID -table tableID'
 func TestMultiStreamerInsertTableToBigQuery(t *testing.T) {
-	flag.Parse()
+	t.Parallel()
 
-	// Validate custom parameters.
-	if *keyPath == "" {
-		t.Fatal("missing key parameter")
-	}
-	if *projectID == "" {
-		t.Fatal("missing project parameter")
-	}
-	if *datasetID == "" {
-		t.Fatal("missing dataset parameter")
-	}
-	if *tableID == "" {
-		t.Fatal("missing table parameter")
-	}
-	if *jsonPath == "" {
-		t.Fatal("missing json parameter")
-	}
+	assert := assert.New(t)
+	require := require.New(t)
 
 	// Read JSON data.
 	f, err := os.Open(*jsonPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
+	defer func() { assert.NoError(f.Close()) }()
 	decoder := json.NewDecoder(f)
 	jsonData := []map[string]interface{}{}
-	err = decoder.Decode(&jsonData)
-	if err != nil {
-		t.Fatal("json decoding error:", err)
-	}
-
-	jwtConfig, err := NewJWTConfig(*keyPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(decoder.Decode(&jsonData))
 
 	// Set flush max delay threshold to 1 second so sub-streamers will flush
 	// almost immediately.
 	s, err := NewMultiStreamer(jwtConfig, 3, 5, 1*time.Second, 1*time.Second, 3)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Convert file JSON data to BigQuery JSON type, and queue them in streamer.
 	for _, row := range jsonData {
@@ -91,10 +104,7 @@ func TestMultiStreamerInsertTableToBigQuery(t *testing.T) {
 	for readErrors {
 		select {
 		case err, ok := <-s.Errors:
-			if !ok {
-				t.Fatal("Error channel is closed")
-			}
-
+			assert.True(ok, "Error channel is closed")
 			t.Log("BigQuery Error:", err)
 		default:
 			t.Log("No errors")

--- a/streamer_example_test.go
+++ b/streamer_example_test.go
@@ -38,6 +38,9 @@ func ExampleStreamer() {
 
 	// Init a new streamer.
 	s, err := NewStreamer(service, maxRows, maxDelay, sleepBeforeRetry, maxRetryInsert)
+	if err != nil {
+		log.Fatalln(err)
+	}
 
 	// Start multi-streamer and workers.
 	// A Streamer (NOT a MultiStreamer) is blocking,

--- a/streamer_integration_test.go
+++ b/streamer_integration_test.go
@@ -5,10 +5,14 @@ package bqstreamer
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/jwt"
 	bigquery "google.golang.org/api/bigquery/v2"
 )
 
@@ -18,7 +22,41 @@ var (
 	datasetID = flag.String("dataset", "", "bigquery dataset id")
 	tableID   = flag.String("table", "", "bigquery table id")
 	jsonPath  = flag.String("json", "bigquery_streamer_integration.json", "json file path to be inserted into bigquery")
+
+	jwtConfig *jwt.Config
 )
+
+func init() {
+	flag.Parse()
+
+	// Validate custom parameters.
+	crash := true
+SANITY:
+	switch {
+	case *keyPath == "":
+		fmt.Println("missing key parameter")
+	case *projectID == "":
+		fmt.Println("missing project parameter")
+	case *datasetID == "":
+		fmt.Println("missing dataset parameter")
+	case *tableID == "":
+		fmt.Println("missing table parameter")
+	case *jsonPath == "":
+		fmt.Println("missing json parameter")
+	default:
+		var err error
+		if jwtConfig, err = NewJWTConfig(*keyPath); err != nil {
+			fmt.Println(err)
+			break SANITY
+		}
+		return
+	}
+
+	if crash {
+		flag.Usage()
+		os.Exit(2)
+	}
+}
 
 // TestInsertTableToBigQuery test stream inserting a row (given as argument)
 // 5 times to BigQuery, and logs the response.
@@ -27,52 +65,26 @@ var (
 //
 // Usage: 'go test -v -tags=integration -key /path/to/key.json -project projectID -dataset datasetID -table tableID'
 func TestInsertTableToBigQuery(t *testing.T) {
-	flag.Parse()
+	t.Parallel()
 
-	// Validate custom parameters.
-	if *keyPath == "" {
-		t.Fatal("missing key parameter")
-	}
-	if *projectID == "" {
-		t.Fatal("missing project parameter")
-	}
-	if *datasetID == "" {
-		t.Fatal("missing dataset parameter")
-	}
-	if *tableID == "" {
-		t.Fatal("missing table parameter")
-	}
-	if *jsonPath == "" {
-		t.Fatal("missing json parameter")
-	}
+	assert := assert.New(t)
+	require := require.New(t)
 
 	// Read JSON data.
 	f, err := os.Open(*jsonPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
+	defer func() { assert.NoError(f.Close()) }()
+
 	decoder := json.NewDecoder(f)
 	jsonData := []map[string]interface{}{}
-	err = decoder.Decode(&jsonData)
-	if err != nil {
-		t.Fatal("json decoding error:", err)
-	}
-
-	jwtConfig, err := NewJWTConfig(*keyPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(decoder.Decode(&jsonData))
 
 	service, err := NewBigQueryService(jwtConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Set flush threshold to 5 so flush will happen immediately.
 	s, err := NewStreamer(service, 5, 1*time.Second, 1*time.Second, 3)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Convert file JSON data to BigQuery JSON type, and queue them in streamer.
 	for _, row := range jsonData {
@@ -84,19 +96,18 @@ func TestInsertTableToBigQuery(t *testing.T) {
 	}
 
 	// Override insertAll() function to call the original one and notify "flushed" via channel.
-	flushed := make(chan bool)
+	flushed := make(chan struct{})
 	s.insertAll = func() {
 		s.insertAllToBigQuery()
-		flushed <- true
+		flushed <- struct{}{}
 	}
 
 	// Start the server and wait enough time for the server to flush.
-	timer := time.NewTimer(10 * time.Second)
 	go s.Start()
 	select {
 	case <-flushed:
-	case <-timer.C:
-		t.Error("insertAll() didn't happen fast enough")
+	case <-time.After(10 * time.Second):
+		assert.Fail("insertAll() didn't happen fast enough")
 	}
 	s.Stop()
 
@@ -106,10 +117,7 @@ func TestInsertTableToBigQuery(t *testing.T) {
 	for readErrors {
 		select {
 		case err, ok := <-s.Errors:
-			if !ok {
-				t.Fatal("Error channel is closed")
-			}
-
+			assert.True(ok, "Error channel is closed")
 			t.Log("BigQuery Error:", err)
 		default:
 			t.Log("No errors")

--- a/streamer_test.go
+++ b/streamer_test.go
@@ -5,194 +5,135 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	bigquery "google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/googleapi"
 )
 
 // TestNewStreamer tests creating a new Streamer.
 func TestNewStreamer(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	var err error
+
 	// Test sending bad arguments.
-	s, err := NewStreamer(nil, 0, 1*time.Second, 1*time.Second, 10)
-	if err == nil {
-		t.Error("New streamer with 0 max rows should've failed")
-	}
+	_, err = NewStreamer(nil, 0, 1*time.Second, 1*time.Second, 10)
+	assert.Error(err)
+	_, err = NewStreamer(nil, -1, 1*time.Second, 1*time.Second, 10)
+	assert.Error(err)
+	_, err = NewStreamer(nil, 10, 0, 1*time.Second, 10)
+	assert.Error(err)
+	_, err = NewStreamer(nil, 10, -1*time.Nanosecond, 1*time.Second, 10)
+	assert.Error(err)
+	_, err = NewStreamer(nil, 10, 1*time.Nanosecond, -1*time.Second, 10)
+	assert.Error(err)
+	_, err = NewStreamer(nil, 10, 1*time.Nanosecond, -1*time.Second, -1)
+	assert.Error(err)
 
-	s, err = NewStreamer(nil, -1, 1*time.Second, 1*time.Second, 10)
-	if err == nil {
-		t.Error("New streamer with -1 max rows should've failed")
-	}
-
-	s, err = NewStreamer(nil, 10, 0, 1*time.Second, 10)
-	if err == nil {
-		t.Error("New streamer with 0 max delay should've failed")
-	}
-
-	s, err = NewStreamer(nil, 10, -1*time.Nanosecond, 1*time.Second, 10)
-	if err == nil {
-		t.Error("New streamer with -1 nanosecond max delay should've failed")
-	}
-
-	s, err = NewStreamer(nil, 10, 1*time.Nanosecond, -1*time.Second, 10)
-	if err == nil {
-		t.Error("New multi-streamer with -1 second sleep before retry should've failed")
-	}
-
-	s, err = NewStreamer(nil, 10, 1*time.Nanosecond, -1*time.Second, -1)
-	if err == nil {
-		t.Error("New multi-streamer with -1 max retry insert sleep should've failed")
-	}
-
-	// Test sending valid arguments.
-	s, err = NewStreamer(nil, 10, 1*time.Second, 1*time.Second, 10)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if s.rowChannel == nil {
-		t.Error("Row channel is nil")
-	}
-	if len(s.rowChannel) != 0 {
-		t.Error("Row channel isn't empty")
-	}
-	if cap(s.rowChannel) != 10 {
-		t.Errorf("cap(rowChannel) != 10 (is %d)", len(s.rowChannel))
-	}
-
-	if s.rows == nil {
-		t.Error("rows is nil")
-	}
-
-	if s.rowIndex != 0 {
-		t.Errorf("rowIndex != 0 (is %d)", s.rowIndex)
-	}
-
-	if s.MaxDelay != 1*time.Second {
-		t.Errorf("maxDelay != 1 second (is %.2f seconds)", s.MaxDelay.Seconds())
-	}
-
-	if s.SleepBeforeRetry != 1*time.Second {
-		t.Errorf("sleepBeforeRetry != 1 second (is %.2f seconds)", s.SleepBeforeRetry.Seconds())
-	}
-
-	if s.MaxRetryInsert != 10 {
-		t.Errorf("maxRetryInsert != 10 (is %d)", s.MaxRetryInsert)
-	}
-
-	if s.stopChannel == nil {
-		t.Error("Stop channel is nil")
-	}
-	if len(s.stopChannel) != 0 {
-		t.Error("Stop channel isn't empty")
-	}
-
-	if s.Errors == nil {
-		t.Error("Error channel is nil")
-	}
-	if len(s.Errors) != 0 {
-		t.Error("Error channel isn't empty")
-	}
-
-	if s.Start == nil {
-		t.Error("s.Start() is nil")
-	}
-
-	if s.Stop == nil {
-		t.Error("s.Stop() is nil")
-	}
-
-	if s.flush == nil {
-		t.Error("s.flush() is nil")
-	}
-
-	if s.insertAll == nil {
-		t.Error("s.insretAll() is nil")
-	}
-
-	if s.insertTable == nil {
-		t.Error("s.insretTable() is nil")
-	}
+	// Test valid arguments.
+	s, err := NewStreamer(nil, 10, 1*time.Second, 1*time.Second, 10)
+	assert.NoError(err)
+	assert.NotNil(s.rowChannel)
+	assert.Empty(s.rowChannel)
+	assert.Equal(10, cap(s.rowChannel))
+	assert.NotNil(s.rows)
+	assert.Equal(0, s.rowIndex)
+	assert.Equal(1*time.Second, s.MaxDelay)
+	assert.Equal(1*time.Second, s.SleepBeforeRetry)
+	assert.Equal(10, s.MaxRetryInsert)
+	assert.NotNil(s.stopChannel)
+	assert.Empty(s.stopChannel)
+	assert.NotNil(s.Errors)
+	assert.Empty(s.Errors)
+	assert.NotNil(s.Start)
+	assert.NotNil(s.Stop)
+	assert.NotNil(s.flush)
+	assert.NotNil(s.insertAll)
+	assert.NotNil(s.insertTable)
 }
 
-// TestSTop calls Stop(), starts a streamer, and checks if it immidiately stopped.
+// TestStop calls Stop(), starts a streamer, and checks if it immediately stopped.
 func TestStop(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set delay threshold to be large enough so we could test if stop message
 	// caused streamer to stop and flush.
 	s, err := NewStreamer(nil, 100, 1*time.Minute, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Override flush function to just send a "flushed" notification,
 	// instead of actually sending to BigQuery.
-	flushed := make(chan bool)
-	s.flush = func() {
-		flushed <- true
-	}
+	flushed := make(chan struct{})
+	s.flush = func() { flushed <- struct{}{} }
 
 	go s.Stop()
-
-	if stop := <-s.stopChannel; !stop {
-		t.Error("No shutdown message passed in shutdown channel upon calling Stop()")
+	select {
+	case <-s.stopChannel:
+	case <-time.After(1 * time.Second):
+		assert.Fail("a stop message wasn't sent on s.stopChannel fast enough")
 	}
 
 	// Test if streamer flushes quickly after a stop signal is sent.
 	go s.Stop()
-	timer := time.NewTimer(1 * time.Second)
 	go s.Start()
 	select {
 	case <-flushed:
-	case <-timer.C:
-		t.Error("flush() wasn't called fast enough")
+	case <-time.After(1 * time.Second):
+		assert.Fail("flush() wasn't called fast enough")
 	}
 }
 
 // TestQueueRow tests queueing a row.
 func TestQueueRow(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	s, err := NewStreamer(nil, 10, 1*time.Second, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	data := map[string]bigquery.JsonValue{"test_key": "test_value"}
 	s.QueueRow("p", "d", "t", data)
 
-	q := <-s.rowChannel
-
-	if q.projectID != "p" {
-		t.Errorf("Row's projectID %s is different than expected %s", q.projectID, "p")
+	var q *row
+	select {
+	case q = <-s.rowChannel:
+	default:
+		require.Fail("no row on s.rowChannel")
 	}
 
-	if q.datasetID != "d" {
-		t.Errorf("Row's datasetID %s is different than expected %s", q.datasetID, "d")
-	}
+	assert.Equal("p", q.projectID)
+	assert.Equal("d", q.datasetID)
+	assert.Equal("t", q.tableID)
 
-	if q.tableID != "t" {
-		t.Errorf("Row's tableID %s is different than expected %s", q.tableID, "t")
-	}
-
-	if v, ok := q.data["test_key"]; !ok {
-		t.Error("Row's data key test_key non existent")
-	} else if v != data["test_key"] {
-		t.Errorf("Row's data value %s different than expected %s", v, data["test_key"])
+	if v, ok := q.data["test_key"]; assert.True(ok) {
+		assert.Equal(v, data["test_key"])
 	}
 }
 
 // TestMaxDelayFlushCall tests streamer is calling flush() to BigQuery when maxDelay
 // timer expires.
 func TestMaxDelayFlushCall(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set maxRows = 10 and insert a single line, so we can be sure flushing
 	// occured by delay timer expiring.
 	s, err := NewStreamer(nil, 10, 1*time.Second, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Override flush function to just send a "flushed" notification,
 	// instead of actually sending to BigQuery.
-	flushed := make(chan bool)
-	s.flush = func() {
-		flushed <- true
-	}
+	flushed := make(chan struct{})
+	s.flush = func() { flushed <- struct{}{} }
 
 	data := map[string]bigquery.JsonValue{"test_key": "test_value"}
 	r := row{"p", "d", "t", data}
@@ -202,47 +143,43 @@ func TestMaxDelayFlushCall(t *testing.T) {
 	// Start streamer and measure time it should take to flush by maxDelay.
 	// Add a small interval to timer to avoid failing when our timer expired
 	// just a moment before streamer's timer.
-	timer := time.NewTimer(s.MaxDelay + 1*time.Millisecond)
 	go s.Start()
+	defer s.Stop()
 
 	// Fail if no flush happened in maxDelay time.
 	select {
 	case <-flushed:
-	case <-timer.C:
-		t.Errorf("flush() wasn't called in maxDelay time (%.2f seconds)", s.MaxDelay.Seconds())
+	case <-time.After(s.MaxDelay + 1*time.Millisecond):
+		assert.Fail("flush() wasn't called in maxDelay time (%.2f seconds)", s.MaxDelay.Seconds())
 	}
-
-	s.Stop()
 
 	// Flushing doesn't actually flush in this test, so s.rows still holds what
 	// we inserted.
-	if s.rows[0].projectID != r.projectID {
-		t.Errorf("Inserted row %s wasn't queued in rows (was %s)", r, *s.rows[0])
-	}
+	assert.Equal(r.projectID, s.rows[0].projectID)
 }
 
 // TestMaxRowsFlushCal tests streamer is calling flush() to insert BigQuery when maxRows have
 // been queued.
 func TestMaxRowsFlushCall(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set a long delay before flushing, so we can be sure flushing occured due
 	// to rows filling up.
 	s, err := NewStreamer(nil, 10, 1*time.Minute, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Override flush function to just send a "flushed" notification,
 	// instead of actually sending to BigQuery.
-	flushed := make(chan bool)
-	s.flush = func() {
-		flushed <- true
-	}
+	flushed := make(chan struct{})
+	s.flush = func() { flushed <- struct{}{} }
 
 	data := map[string]bigquery.JsonValue{"test_key": "test_value"}
 	r := row{"p", "d", "t", data}
 
 	// Start streamer and measure time it should take to flush by maxRows.
-	timer := time.NewTimer(1 * time.Microsecond)
 	go s.Start()
 
 	// Insert 10 rows to force flushing by maxRows.
@@ -253,8 +190,8 @@ func TestMaxRowsFlushCall(t *testing.T) {
 	// Test if flushing happened almost immediately, forced by rows queue being filled.
 	select {
 	case <-flushed:
-	case <-timer.C:
-		t.Error("flush() wasn't called by rows queue getting filled")
+	case <-time.After(10 * time.Microsecond):
+		assert.Fail("flush() wasn't called by rows queue getting filled")
 	}
 
 	s.Stop()
@@ -262,34 +199,33 @@ func TestMaxRowsFlushCall(t *testing.T) {
 	// Flushing doesn't actually flush in this test, so s.rows still holds what
 	// we inserted.
 	for i := 0; i <= 9; i++ {
-		if s.rows[i].projectID != r.projectID {
-			t.Errorf("Inserted row %s wasn't queued in rows (was %s)", r, *s.rows[i])
-		}
+		require.Equal(r.projectID, s.rows[i].projectID)
 	}
 }
 
 // TestInsertAll queues 20 rows to 4 tables, 5 to each row,
 // and tests if rows were inserted to a mock project-dataset-table-rows type.
 func TestInsertAll(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// We intend to insert 20 rows in this test, so set maxRows = 20 and delay
 	// to be long enough so flush will occur due to rows queue filling up.
 	s, err := NewStreamer(nil, 20, 1*time.Minute, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Mock insertTable function to cache all rows from all tables to a local variable.
 	// Will be used for testing which rows were actually "inserted".
 	ps := map[string]project{}
-	flushed := make(chan bool)
+	flushed := make(chan struct{})
 
 	s.insertTable = func(pId, dId, tId string, tt table) (r *bigquery.TableDataInsertAllResponse, err error) {
 		// Add all table rows to a local projects-datasets-table map,
 		// mocking rows that were inserted to BigQuery, which we will test against.
 		for i, tr := range tt {
-			if tr == nil {
-				t.Errorf("%s.%s.%s.row[%d] is nil", pId, dId, tId, i)
-			}
+			assert.NotNil(tr, fmt.Sprintf("%s.%s.%s.row[%d]", pId, dId, tId, i))
 
 			// Mock "insert row" to table: Create project, dataset and table
 			// if uninitalized.
@@ -301,7 +237,7 @@ func TestInsertAll(t *testing.T) {
 		r = &bigquery.TableDataInsertAllResponse{}
 
 		// Notify that this table was mock "flushed".
-		flushed <- true
+		flushed <- struct{}{}
 
 		return
 	}
@@ -318,69 +254,52 @@ func TestInsertAll(t *testing.T) {
 
 	// Start streamer and wait for 4 flushes to happen, one for each table.
 	// Fail if flushes take too long.
-	timer := time.NewTimer(1 * time.Millisecond)
 	go s.Start()
 	for i := 0; i < 4; i++ {
 		select {
 		case <-flushed:
-		case <-timer.C:
-			t.Fatalf("flush() %d wasn't called fast enough", i)
+		case <-time.After(1 * time.Millisecond):
+			assert.Fail(fmt.Sprintf("flush() %d wasn't called fast enough", i))
 		}
 	}
 	s.Stop()
 
-	if s.rowIndex != 0 {
-		t.Error("rowIndex not reset to 0 after all flushes were done")
-	}
+	assert.Equal(0, s.rowIndex, "rowIndex not reset to 0 after all flushes were done")
 
 	// Check all queued projects, datasets, and tables were actually mock "inserted".
-	if _, ok := ps["p1"]; !ok {
-		t.Error("p1 project missing from inserted projects")
-	}
-	if _, ok := ps["p2"]; !ok {
-		t.Error("p1 project missing from inserted projects")
-	}
-	if _, ok := ps["p1"]["d1"]; !ok {
-		t.Error("p1.d1 dataset missing from inserted datasets")
-	}
-	if _, ok := ps["p1"]["d2"]; !ok {
-		t.Error("p1.d2 dataset missing from inserted datasets")
-	}
-	if _, ok := ps["p1"]["d1"]["t1"]; !ok {
-		t.Error("p1.d1.t1 table missing from inserted datasets")
-	}
-	if _, ok := ps["p1"]["d1"]["t2"]; !ok {
-		t.Error("p1.d1.t2 table missing from inserted datasets")
-	}
+	// We can't use assert.Equals() here since the table rows have a generated
+	// row ID.
+	_, ok := ps["p1"]
+	require.True(ok)
+	_, ok = ps["p2"]
+	require.True(ok)
+	_, ok = ps["p1"]["d1"]
+	require.True(ok)
+	_, ok = ps["p1"]["d2"]
+	require.True(ok)
+	_, ok = ps["p1"]["d1"]["t1"]
+	require.True(ok)
+	_, ok = ps["p1"]["d1"]["t2"]
+	require.True(ok)
 
 	// Check no more than 2 projects, 2 datasets, and 2 tables were mock "inserted".
-	if len(ps) != 2 {
-		t.Errorf("There were more than 2 projects inserted (were %d)", len(ps))
-	}
-	if len(ps["p1"]) != 2 {
-		t.Errorf("There were more than 2 datasets inserted (were %d)", len(ps["p1"]))
-	}
-	if len(ps["p1"]["d1"]) != 2 {
-		t.Errorf("There were more than 2 tables inserted (were %d)", len(ps["p1"]["d1"]))
-	}
+	require.Len(ps, 2)
+	require.Len(ps["p1"], 2)
+	require.Len(ps["p1"]["d1"], 2)
 
 	// Check all rows from all tables were mock "inserted".
 	checkRows := func(ps map[string]project, p, d, tt string, num int) {
 		for i := 0; i < num; i++ {
 			r := ps[p][d][tt][i]
-			if r == nil {
-				t.Errorf("Row %d missing from table %s.%s.%s", i, p, d, tt)
-			}
+			require.NotNil(r, fmt.Sprintf("Row %d missing from table %s.%s.%s", i, p, d, tt))
 
-			if v, ok := r.jsonValue[fmt.Sprintf("k%d", i)]; !ok {
-				t.Errorf("Key k%d missing from %s.%s.%s.row[%d] (row is %s)", i, p, d, tt, i, r)
-			} else if v != fmt.Sprintf("v%d", i) {
-				t.Errorf("%s.%s.%s.row[%d] key's value is not v%d (is %s)", p, d, tt, i, i, v)
-			}
+			v, ok := r.jsonValue[fmt.Sprintf("k%d", i)]
+			require.True(ok, fmt.Sprintf("Key k%d missing from %s.%s.%s.row[%d] (row is %s)", i, p, d, tt, i, r))
+			require.Equal(v, fmt.Sprintf("v%d", i), fmt.Sprintf("%s.%s.%s.row[%d] key's value is not v%d (is %s)", p, d, tt, i, i, v))
 		}
 
 		if len(ps[p][d][tt]) > num {
-			t.Errorf("There are more rows in %s.%s.%s than expected (there are %d)", p, d, tt, len(ps[p][d][tt]))
+			require.Fail("There are more rows in %s.%s.%s than expected (there are %d)", p, d, tt, len(ps[p][d][tt]))
 		}
 	}
 	checkRows(ps, "p1", "d1", "t1", 5)
@@ -393,132 +312,85 @@ func TestInsertAll(t *testing.T) {
 // returns true for specific errors.
 // Currently only for googleapi.Errorgoogleapi.Error.Code = 503 or 500
 func TestShouldRetryInsertAfterError(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	s, err := NewStreamer(nil, 5, 1*time.Minute, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Test whether a GoogleAPI HTTP 503 error returns true.
 	// i.e. the function decides the request related to this error should be retried.
-	if !s.shouldRetryInsertAfterError(
+	assert.True(s.shouldRetryInsertAfterError(
 		&googleapi.Error{Code: 503, Message: "m", Body: "b", Errors: []googleapi.ErrorItem{
 			googleapi.ErrorItem{Reason: "r1", Message: "m1"},
-			googleapi.ErrorItem{Reason: "r2", Message: "m2"}}}) {
-		t.Error("GoogleAPI HTTP 503 insert error wasn't marked as \"to be retried\"")
-	}
+			googleapi.ErrorItem{Reason: "r2", Message: "m2"}}}),
+		"GoogleAPI HTTP 503 insert error wasn't marked as \"to be retried\"")
 
 	// Test whether errors above were logged.
 	select {
 	case err = <-s.Errors:
-		if gerr, ok := err.(*googleapi.Error); !ok {
-			t.Error("Logged error after GoogleAPI HTTP 503 insert error wasn't a GoogleAPI error")
-		} else {
-			if gerr.Code != 503 {
-				t.Error("Logged GoogleAPI HTTP 503 error code != 503")
-			}
-			if gerr.Message != "m" {
-				t.Error("Logged GoogleAPI HTTP 503 error code != m")
-			}
-			if gerr.Body != "b" {
-				t.Error("Logged GoogleAPI HTTP 503 error code != b")
-			}
-
-			if len(gerr.Errors) != 2 {
-				t.Errorf("Logged GoogleAPI HTTP 503 error code errors length != 2, is: %d", len(gerr.Errors))
-			} else {
-				if gerr.Errors[0].Reason != "r1" {
-					t.Error("Logged GoogleAPI HTTP 503 error code 1st error item reason != r1")
-				}
-				if gerr.Errors[0].Message != "m1" {
-					t.Error("Logged GoogleAPI HTTP 503 error code 1st error item message != m1")
-				}
-				if gerr.Errors[1].Reason != "r2" {
-					t.Error("Logged GoogleAPI HTTP 503 error code 2st error item reason != r2")
-				}
-				if gerr.Errors[1].Message != "m2" {
-					t.Error("Logged GoogleAPI HTTP 503 error code 2st error item message != m2")
-				}
-			}
+		if assert.IsType(&googleapi.Error{}, err) {
+			assert.Equal(
+				&googleapi.Error{Code: 503, Message: "m", Body: "b", Errors: []googleapi.ErrorItem{
+					googleapi.ErrorItem{Reason: "r1", Message: "m1"},
+					googleapi.ErrorItem{Reason: "r2", Message: "m2"}}},
+				err.(*googleapi.Error))
 		}
 	default:
-		t.Error("Logged error after GoogleAPI 503 insert error is missing")
+		assert.Fail("Logged error after GoogleAPI 503 insert error is missing")
 	}
 
 	// Test another GoogleAPI response with a different status code,
 	// and check the function returns false.
-	if s.shouldRetryInsertAfterError(
+	assert.False(s.shouldRetryInsertAfterError(
 		&googleapi.Error{Code: 501, Message: "m", Body: "b", Errors: []googleapi.ErrorItem{
 			googleapi.ErrorItem{Reason: "r1", Message: "m1"},
-			googleapi.ErrorItem{Reason: "r2", Message: "m2"}}}) {
-		t.Error("GoogleAPI HTTP 500 insert error was marked as \"to be retried\"")
-	}
+			googleapi.ErrorItem{Reason: "r2", Message: "m2"}}}),
+		"GoogleAPI HTTP 500 insert error was marked as \"to be retried\"")
 
 	// Test whether errors above were logged.
 	select {
 	case err = <-s.Errors:
-		if gerr, ok := err.(*googleapi.Error); !ok {
-			t.Error("Logged error after GoogleAPI HTTP 503 insert error wasn't a GoogleAPI error")
-		} else {
-			if gerr.Code != 501 {
-				t.Error("Logged GoogleAPI HTTP 503 error code != 503")
-			}
-			if gerr.Message != "m" {
-				t.Error("Logged GoogleAPI HTTP 503 error code != m")
-			}
-			if gerr.Body != "b" {
-				t.Error("Logged GoogleAPI HTTP 503 error code != b")
-			}
-
-			if len(gerr.Errors) != 2 {
-				t.Errorf("Logged GoogleAPI HTTP 503 error code errors length != 2, is: %d", len(gerr.Errors))
-			} else {
-				if gerr.Errors[0].Reason != "r1" {
-					t.Error("Logged GoogleAPI HTTP 503 error code 1st error item reason != r1")
-				}
-				if gerr.Errors[0].Message != "m1" {
-					t.Error("Logged GoogleAPI HTTP 503 error code 1st error item message != m1")
-				}
-				if gerr.Errors[1].Reason != "r2" {
-					t.Error("Logged GoogleAPI HTTP 503 error code 2st error item reason != r2")
-				}
-				if gerr.Errors[1].Message != "m2" {
-					t.Error("Logged GoogleAPI HTTP 503 error code 2st error item message != m2")
-				}
-			}
+		if assert.IsType(&googleapi.Error{}, err) {
+			assert.Equal(
+				&googleapi.Error{Code: 501, Message: "m", Body: "b", Errors: []googleapi.ErrorItem{
+					googleapi.ErrorItem{Reason: "r1", Message: "m1"},
+					googleapi.ErrorItem{Reason: "r2", Message: "m2"}}},
+				err.(*googleapi.Error))
 		}
 	default:
-		t.Error("Logged error after GoogleAPI 500 insert error is missing")
+		assert.Fail("Logged error after GoogleAPI 500 insert error is missing")
 	}
 
 	// Test a non-GoogleAPI error, but a a generic error instead.
-	if s.shouldRetryInsertAfterError(fmt.Errorf("Non-GoogleAPI error")) {
-		t.Error("Non-GoogleAPI error was marked as \"to be retried\"")
-	}
+	assert.False(s.shouldRetryInsertAfterError(fmt.Errorf("Non-GoogleAPI error")),
+		"Non-GoogleAPI error was marked as \"to be retried\"")
 
 	// Test whether the error above was logged.
 	select {
 	case err = <-s.Errors:
-		if _, ok := err.(*googleapi.Error); ok {
-			t.Error("Logged error after Non-GoogleAPI error is of *googleapi.Error type")
-		} else if err.Error() != "Non-GoogleAPI error" {
-			t.Error("Logged non-GoogleAPI error != \"Non-GoogleAPI error\"")
-		}
+		assert.EqualError(err, "Non-GoogleAPI error")
 	default:
-		t.Error("Logged error after Non-GoogleAPI error is missing")
+		assert.Fail("Logged error after Non-GoogleAPI error is missing")
 	}
 }
 
 // TestRemoveRowsFromTable inserts rows, then removes a part of them.
 // It then checks whether the correct rows where indeed removed.
 func TestRemoveRowsFromTable(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Make maxRows bigger (10) than the amount of rows we're going to insert
 	// in this test (5), so flushing won't happen because of this.
 	// Also, make maxDelay longer than the amount of time this test is going to take,
 	// for the same reason.
 	s, err := NewStreamer(nil, 10, 1*time.Minute, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Split 10 rows equally to two tables.
 
@@ -537,16 +409,12 @@ func TestRemoveRowsFromTable(t *testing.T) {
 	// Removal is done in place, switching places with the last element in slice.
 	// Thus row 2 should be first (switched with row 0 upon its deletion),
 	// and row 1 afterwards.
-	if val, ok := filtered[0].jsonValue["k12"]; !ok {
-		t.Errorf("Key k12 is not in row filtered[0]: %s", filtered)
-	} else if val != "v12" {
-		t.Errorf("row filtered[0][k12] != v12 is: %s", filtered[0].jsonValue["k12"])
+	if val, ok := filtered[0].jsonValue["k12"]; assert.True(ok) {
+		assert.Equal("v12", val)
 	}
 
-	if val, ok := filtered[1].jsonValue["k11"]; !ok {
-		t.Errorf("Key k11 is not in row filtered[1]: %s", filtered)
-	} else if val != "v11" {
-		t.Errorf("row filtered[1][k11] != v11 is: %s", filtered[1].jsonValue["k11"])
+	if val, ok := filtered[1].jsonValue["k11"]; assert.True(ok) {
+		assert.Equal("v11", val)
 	}
 }
 
@@ -554,14 +422,17 @@ func TestRemoveRowsFromTable(t *testing.T) {
 // It then tests whether correct rows were removed and if the right removed
 // indexes were returned by filterRejectedRows()
 func TestFilterRejectedRows(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Make maxRows bigger (10) than the amount of rows we're going to insert
 	// in this test (5), so flushing won't happen because of this.
 	// Also, make maxDelay longer than the amount of time this test is going to take,
 	// for the same reason.
 	s, err := NewStreamer(nil, 10, 1*time.Minute, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Distribute 10 rows equally to 2 tables.
 	d := map[string]table{
@@ -603,50 +474,34 @@ func TestFilterRejectedRows(t *testing.T) {
 	rejected1 := s.filterRejectedRows(r1, "p", "d", "t1", d)
 	rejected2 := s.filterRejectedRows(r2, "p", "d", "t2", d)
 
-	if len(rejected1) != 3 {
-		t.Errorf("len() != 3 for insert 1 rejected indexes, is: %d", len(rejected1))
-	} else {
-		// Test the rejected rows' indexes is correct.
-		for i, e := range []int64{4, 2, 0} {
-			if rejected1[i] == e {
-				t.Errorf("rejected1[%d] != %d, is: %d", i, e, rejected1[i])
-			}
-		}
-
-		// This call's insert request should only include rows 2, 3 in that order.
-		// This is because row 2 was marked as "stopped",
-		// and row 3 wasn't marked by any error at all.
-		//
-		// So, test t1 remaining rows are as mentioned.
-		if len(d["t1"]) != 2 {
-			t.Errorf("len(t1) != 2, is: %d", len(d["t1"]))
-		} else {
-			if val, ok := d["t1"][0].jsonValue["k12"]; !ok {
-				t.Errorf("Key k12 is not in row d[t1][0]: %s", d["t1"])
-			} else if val != "v12" {
-				t.Errorf("row d[t1][0][k12] != v12 is: %s", d["t1"][0].jsonValue["k12"])
-			}
-
-			if val, ok := d["t1"][1].jsonValue["k13"]; !ok {
-				t.Errorf("Key k13 is not in row d[t1][1]: %s", d["t1"])
-			} else if val != "v13" {
-				t.Errorf("row d[t1][1][k13] != v13 is: %s", d["t1"][1].jsonValue["k13"])
-			}
-		}
+	// Test the rejected rows' indexes is correct.
+	require.Equal(3, len(rejected1))
+	for i, e := range []int64{4, 2, 0} {
+		assert.NotEqual(e, rejected1[i], i)
 	}
 
-	if len(rejected2) != 0 {
-		t.Errorf("len() != 0 for insert 2 rejected indexes, is: %d", len(rejected2))
+	// This call's insert request should only include rows 2, 3 in that order.
+	// This is because row 2 was marked as "stopped",
+	// and row 3 wasn't marked by any error at all.
+	//
+	// So, test t1 remaining rows are as mentioned.
+	require.Equal(2, len(d["t1"]))
+	if val, ok := d["t1"][0].jsonValue["k12"]; assert.True(ok) {
+		assert.Equal("v12", val)
 	}
+
+	if val, ok := d["t1"][1].jsonValue["k13"]; assert.True(ok) {
+		assert.Equal("v13", val)
+	}
+
+	assert.Empty(rejected2)
 
 	// Test t2 rows weren't changed at all.
 	for i := 0; i < len(d["t2"]); i++ {
 		k := fmt.Sprintf("k2%d", i)
 		v := fmt.Sprintf("v2%d", i)
-		if val, ok := d["t2"][i].jsonValue[k]; !ok {
-			t.Errorf("Key %s is not in row d[t2][%d]: %s", k, i, d["t2"])
-		} else if val != v {
-			t.Errorf("row d[t2][%d][%s] != v is: %s", i, k, d["t2"][i].jsonValue["k"])
+		if val, ok := d["t2"][i].jsonValue[k]; assert.True(ok) {
+			assert.Equal(v, val)
 		}
 	}
 }
@@ -654,12 +509,15 @@ func TestFilterRejectedRows(t *testing.T) {
 // TestInsertAllWithServerErrorResponse tests if an insert failed with a server
 // error (500, 503) triggers a retry insert.
 func TestInsertAllWithServerErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set a row threshold to 5 so it will flush immediately on calling Start().
 	// Also make retry sleep delay as small as possible and != 0.
 	s, err := NewStreamer(nil, 5, 1*time.Minute, 1*time.Nanosecond, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Queue 5 rows to the same table.
 	for i := 0; i < 5; i++ {
@@ -670,7 +528,7 @@ func TestInsertAllWithServerErrorResponse(t *testing.T) {
 
 	// Mock insertTable function to return mocked errors and notify table was mock "flushed".
 	// Also count the times insertTable() is called to make sure it's retried exactly once.
-	flushed := make(chan bool)
+	flushed := make(chan struct{})
 	calledNum := 0
 	s.insertTable = func(pId, dId, tId string, tt table) (r *bigquery.TableDataInsertAllResponse, err error) {
 		// Return 503 server error on first call, and test if it triggered
@@ -683,25 +541,20 @@ func TestInsertAllWithServerErrorResponse(t *testing.T) {
 		case 1:
 			// This call to insertTable() should keep the table is it is,
 			// and trigger retry after server error.
-			if len(tt) != 5 {
-				t.Error("len(tt) != 5")
-			} else {
-				for i := 0; i < 5; i++ {
-					k := fmt.Sprintf("k%d", i)
-					v := fmt.Sprintf("v%d", i)
-					if val, ok := tt[i].jsonValue[k]; !ok {
-						t.Errorf("Key %s is not in row tt[%d]: %s", k, i, tt)
-					} else if val != v {
-						t.Errorf("row tt[%d][%s] != %s is: %s", i, k, v, tt[i].jsonValue[k])
-					}
+			require.Equal(5, len(tt))
+			for i := 0; i < 5; i++ {
+				k := fmt.Sprintf("k%d", i)
+				v := fmt.Sprintf("v%d", i)
+				if val, ok := tt[i].jsonValue[k]; assert.True(ok) {
+					assert.Equal(v, val)
 				}
 			}
 		default:
-			t.Error("insertTable() was called more than 2 times")
+			assert.Fail("insertTable() was called more than 2 times")
 		}
 
 		// Notify that this table was mock "flushed".
-		flushed <- true
+		flushed <- struct{}{}
 
 		calledNum++
 
@@ -711,44 +564,42 @@ func TestInsertAllWithServerErrorResponse(t *testing.T) {
 	// Start streamer and wait for flush to happen.
 	// Fail if flush takes too long.
 	go s.Start()
+	defer s.Stop()
 
 	// Test HTTP 503 server error response triggered a retry.
-	timer := time.NewTimer(1 * time.Microsecond)
-
+	//
 	// First loop is for testing initial insert,
 	// second is for testing retry insert happened.
 	for i := 0; i < 2; i++ {
 		select {
 		case <-flushed:
-		case <-timer.C:
-			t.Errorf("insert %d didn't happen fast enough", i)
+		case <-time.After(1 * time.Second):
+			assert.Fail(fmt.Sprintf("insert %d didn't happen fast enough", i))
 		}
-		// FIXME for some reason a lot of time is necessary for this iteration to finish.
-		timer.Reset(1 * time.Second)
 	}
 
 	// Make sure insertTable() wasn't called again i.e. no retry happened.
 	// This is done by waiting for a fair amount of time
 	// and testing no flush happened.
-	timer.Reset(1 * time.Second)
 	select {
 	case <-flushed:
-		t.Error("retry insert happened another time after test was finished")
-	case <-timer.C:
+		assert.Fail("retry insert happened another time after test was finished")
+	case <-time.After(1 * time.Microsecond):
 	}
-
-	s.Stop()
 }
 
 // TestInsertAllWithNonServerErrorResponse tests if an insert failed with an error
 // which is NOT server error (503) does NOT trigger a retry insert.
 func TestInsertAllWithNonServerErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set a row threshold to 5 so it will flush immediately on calling Start().
 	// Also make retry sleep delay as small as possible and != 0.
 	s, err := NewStreamer(nil, 5, 1*time.Minute, 1*time.Nanosecond, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Queue 5 rows to the same table.
 	for i := 0; i < 5; i++ {
@@ -759,7 +610,7 @@ func TestInsertAllWithNonServerErrorResponse(t *testing.T) {
 
 	// Mock insertTable function to return mocked errors and notify table was mock "flushed".
 	// Also count the times insertTable() is called to make sure it's retried exactly once.
-	flushed := make(chan bool)
+	flushed := make(chan struct{})
 	calledNum := 0
 	s.insertTable = func(pId, dId, tId string, tt table) (r *bigquery.TableDataInsertAllResponse, err error) {
 		// Return a 501 (not 500, 503) server error on first call,
@@ -770,11 +621,11 @@ func TestInsertAllWithNonServerErrorResponse(t *testing.T) {
 				googleapi.ErrorItem{Reason: "r1", Message: "m1"},
 				googleapi.ErrorItem{Reason: "r2", Message: "m2"}}}
 		default:
-			t.Error("insertTable() was called more than once")
+			require.Fail("insertTable() was called more than once")
 		}
 
 		// Notify that this table was mock "flushed".
-		flushed <- true
+		flushed <- struct{}{}
 
 		calledNum++
 
@@ -782,36 +633,36 @@ func TestInsertAllWithNonServerErrorResponse(t *testing.T) {
 	}
 
 	go s.Start()
+	defer s.Stop()
 
 	// Test initial insert.
-	timer := time.NewTimer(1 * time.Microsecond)
 	select {
 	case <-flushed:
-	case <-timer.C:
-		t.Errorf("initial insert didn't happen fast enough")
+	case <-time.After(1 * time.Second):
+		require.Fail("initial insert didn't happen fast enough")
 	}
 
 	// Make sure insertTable() wasn't called again i.e. no retry happened.
-	timer.Reset(1 * time.Second)
 	select {
 	case <-flushed:
-		t.Error("retry insert happened even though server error != 503")
-	case <-timer.C:
+		assert.Fail("retry insert happened even though server error != 503")
+	case <-time.After(1 * time.Microsecond):
 	}
-
-	s.Stop()
 }
 
 // TestMaxRetryInsert tests if a repeatedly failing insert attempt
 // (failing with non-rejected rows errors) is eventually dropped and ignored,
 // and streamer is moving on to the next table insert.
 func TestMaxRetryInsert(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set a row threshold to 5 so it will flush immediately on calling Start().
 	// Also make retry sleep delay as small as possible and != 0.
 	s, err := NewStreamer(nil, 5, 1*time.Minute, 1*time.Nanosecond, 3)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Queue 5 rows to the same table.
 	for i := 0; i < 5; i++ {
@@ -822,25 +673,21 @@ func TestMaxRetryInsert(t *testing.T) {
 
 	// Mock insertTable function to return mocked errors and notify table was mock "flushed".
 	// Also count the times insertTable() is called to make sure it's retried exactly 3 times.
-	insertCalled := make(chan bool)
+	insertCalled := make(chan struct{})
 	calledNum := 0
 	s.insertTable = func(pId, dId, tId string, tt table) (r *bigquery.TableDataInsertAllResponse, err error) {
 		// Return Google API HTTP 503 error on every call, which should be retried and logged.
 		// Thus, we should expect 3 logged errors.
 		if calledNum < 3 {
-			err = &googleapi.Error{
-				Code:    503,
-				Message: "m",
-				Body:    "b",
-				Errors: []googleapi.ErrorItem{
-					googleapi.ErrorItem{Reason: "r1", Message: "m1"},
-					googleapi.ErrorItem{Reason: "r2", Message: "m2"}}}
+			err = &googleapi.Error{Code: 503, Message: "m", Body: "b", Errors: []googleapi.ErrorItem{
+				googleapi.ErrorItem{Reason: "r1", Message: "m1"},
+				googleapi.ErrorItem{Reason: "r2", Message: "m2"}}}
 		} else {
-			t.Error("insertTable() was called more than 3 times")
+			assert.Fail("insertTable() was called more than 3 times")
 		}
 
 		// Notify that this table was mock "flushed".
-		insertCalled <- true
+		insertCalled <- struct{}{}
 
 		calledNum++
 
@@ -850,20 +697,16 @@ func TestMaxRetryInsert(t *testing.T) {
 	// Start streamer and wait for flush to happen.
 	// Fail if flush takes too long.
 	go s.Start()
+	defer s.Stop()
 
 	// Test each insert logged an error.
-	//
-	// FIXME for some reason a lof time is necessary for this test to finish successfully.
-	// Otherwise timer expires before insert table is called.
-	// See other FIXME at the end of this block.
-	timer := time.NewTimer(1 * time.Second)
 	for i := 0; i < 3; i++ {
 		select {
-		case <-timer.C:
-			t.Errorf("insert %d didn't happen fast enough", i)
+		case <-time.After(1 * time.Second):
+			assert.Fail("insert %d didn't happen fast enough", i)
 		case <-insertCalled:
 			// Wait a bit for the current insert table iteration to check for
-			// errorrs and decide whether to retry or not.
+			// errors and decide whether to retry or not.
 			time.Sleep(1 * time.Millisecond)
 
 			// Check that on each insert, an error was logged.
@@ -871,52 +714,45 @@ func TestMaxRetryInsert(t *testing.T) {
 			// which returns an HTTP 503.
 			select {
 			case err, ok := <-s.Errors:
-				if !ok {
-					t.Fatal("Error channel is closed")
-				}
+				assert.True(ok, "Error channel is closed")
 				t.Log("Mocked errors (this is ok):", err)
 			default:
-				t.Errorf("Error %d is missing from error channel", i)
+				assert.Fail(fmt.Sprintf("Error %d is missing from error channel", i))
 			}
 		}
-
-		// FIXME for some reason a lot of time is necessary for this iteration to finish.
-		timer.Reset(1 * time.Second)
 	}
 
 	// Make sure insertTable() wasn't called again i.e. no retry happened.
 	// This is done by waiting for a fair amount of time
 	// and testing no flush happened.
-	timer.Reset(1 * time.Second)
 	select {
 	case <-insertCalled:
-		t.Error("retry insert happened for the 4th time after test was finished")
-	case <-timer.C:
+		assert.Fail("retry insert happened for the 4th time after test was finished")
+	case <-time.After(1 * time.Second):
 	}
 
 	// Test "too many retries, dropping insert" error was logged.
 	select {
 	case err, ok := <-s.Errors:
-		if !ok {
-			t.Fatal("Error channel is closed")
-		}
+		assert.True(ok, "Error channel is closed")
 		t.Log("Mocked errors (this is ok):", err)
 	default:
-		t.Error("Error \"too many retries\" is missing from error channel")
+		assert.Fail("Error \"too many retries\" is missing from error channel")
 	}
-
-	s.Stop()
 }
 
 // TestInsertAllWithRejectedResponse tests if an insert failed with rejected
 // rows triggers a retry insert only with non-rejected rows.
 func TestInsertAllWithRejectedResponse(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set a row threshold to 5 so it will flush immediately on calling Start().
 	// Also make retry sleep delay as small as possible and != 0.
 	s, err := NewStreamer(nil, 5, 1*time.Minute, 1*time.Nanosecond, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Queue 5 rows to the same table.
 	for i := 0; i < 5; i++ {
@@ -927,7 +763,7 @@ func TestInsertAllWithRejectedResponse(t *testing.T) {
 
 	// Mock insertTable function to return mocked errors and notify table was mock "flushed".
 	// Also count the times insertTable() is called to make sure it's retried exactly once.
-	flushed := make(chan bool)
+	flushed := make(chan struct{})
 	calledNum := 0
 	s.insertTable = func(pId, dId, tId string, tt table) (r *bigquery.TableDataInsertAllResponse, err error) {
 		// Return a 500 (not 503) server error on first call,
@@ -959,36 +795,27 @@ func TestInsertAllWithRejectedResponse(t *testing.T) {
 			//
 			// Also, these are the indexes that are not filtered because rows 2,4 were marked
 			// as "stopped" and "timeout", and row 3 wasn't marked by any error at all.
-			if len(tt) != 3 {
-				t.Errorf("len(tt) != 3, is: %s", tt)
-			} else {
-				if val, ok := tt[0].jsonValue["k3"]; !ok {
-					t.Errorf("Key k3 is not in row tt[0]: %s", tt)
-				} else if val != "v3" {
-					t.Errorf("row tt[0][k3] != v3 is: %s", tt[0].jsonValue["k3"])
-				}
+			assert.Equal(3, len(tt))
+			if val, ok := tt[0].jsonValue["k3"]; assert.True(ok) {
+				assert.Equal("v3", val)
+			}
 
-				if val, ok := tt[1].jsonValue["k4"]; !ok {
-					t.Errorf("Key k4 is not in row tt[1]: %s", tt)
-				} else if val != "v4" {
-					t.Errorf("row tt[1][k4] != v4 is: %s", tt[1].jsonValue["k4"])
-				}
+			if val, ok := tt[1].jsonValue["k4"]; assert.True(ok) {
+				assert.Equal("v4", val)
+			}
 
-				if val, ok := tt[2].jsonValue["k2"]; !ok {
-					t.Errorf("Key k2 is not in row tt[2]: %s", tt)
-				} else if val != "v2" {
-					t.Errorf("row tt[2][k2] != v2 is: %s", tt[2].jsonValue["k2"])
-				}
+			if val, ok := tt[2].jsonValue["k2"]; assert.True(ok) {
+				assert.Equal("v2", val)
 			}
 
 			// Return 0 insert errors.
 			r = &bigquery.TableDataInsertAllResponse{}
 		default:
-			t.Error("insertTable() was called more than 3 times")
+			assert.Fail("insertTable() was called more than 3 times")
 		}
 
 		// Notify that this table was mock "flushed".
-		flushed <- true
+		flushed <- struct{}{}
 
 		calledNum++
 
@@ -996,44 +823,43 @@ func TestInsertAllWithRejectedResponse(t *testing.T) {
 	}
 
 	go s.Start()
+	defer s.Stop()
 
 	// Test initial insert.
-	timer := time.NewTimer(1 * time.Microsecond)
 	select {
 	case <-flushed:
-	case <-timer.C:
-		t.Error("initial insert didn't happened fast enough")
+	case <-time.After(1 * time.Second):
+		assert.Fail("initial insert didn't happened fast enough")
 
 	}
 
 	// Test insertTable() is called again after rejected rows response.
-	timer.Reset(1 * time.Microsecond)
 	select {
 	case <-flushed:
-	case <-timer.C:
-		t.Error("retry insert didn't happen fast enough after rejected rows response")
+	case <-time.After(1 * time.Microsecond):
+		assert.Fail("retry insert didn't happen fast enough after rejected rows response")
 	}
 
 	// Make sure insertTable() wasn't called again i.e. no retry happened.
-	timer.Reset(1 * time.Second)
 	select {
 	case <-flushed:
-		t.Error("retry insert happened even though no rows were rejected")
-	case <-timer.C:
+		assert.Fail("retry insert happened even though no rows were rejected")
+	case <-time.After(1 * time.Second):
 	}
-
-	s.Stop()
 }
 
 // TestInsertwithAllRowsRejected tests if an insert failed with all rows
 // rejected doesn't trigger a retry insert.
 func TestInsertwithAllRowsRejected(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set a row threshold to 5 so it will flush immediately on calling Start().
 	// Also make retry sleep delay as small as possible and != 0.
 	s, err := NewStreamer(nil, 5, 1*time.Minute, 1*time.Nanosecond, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Queue 5 rows to the same table.
 	for i := 0; i < 5; i++ {
@@ -1044,7 +870,7 @@ func TestInsertwithAllRowsRejected(t *testing.T) {
 
 	// Mock insertTable function to return mocked errors and notify table was mock "flushed".
 	// Also count the times insertTable() is called to make sure it's retried exactly once.
-	flushed := make(chan bool)
+	flushed := make(chan struct{})
 	insertCalled := false
 	s.insertTable = func(pId, dId, tId string, tt table) (r *bigquery.TableDataInsertAllResponse, err error) {
 		// Return a 500 (not 503) server error on first call,
@@ -1065,11 +891,11 @@ func TestInsertwithAllRowsRejected(t *testing.T) {
 					&bigquery.TableDataInsertAllResponseInsertErrors{Index: 4, Errors: []*bigquery.ErrorProto{
 						&bigquery.ErrorProto{Location: "l40", Message: "m40", Reason: "invalid"}}}}}
 		} else {
-			t.Error("insertTable() was called more than 2 times")
+			assert.Fail("insertTable() was called more than 2 times")
 		}
 
 		// Notify that this table was mock "flushed".
-		flushed <- true
+		flushed <- struct{}{}
 
 		insertCalled = true
 
@@ -1077,52 +903,50 @@ func TestInsertwithAllRowsRejected(t *testing.T) {
 	}
 
 	go s.Start()
+	defer s.Stop()
 
 	// Test initial insert.
-	timer := time.NewTimer(1 * time.Microsecond)
 	select {
 	case <-flushed:
-	case <-timer.C:
-		t.Error("initial insert didn't happened fast enough")
+	case <-time.After(1 * time.Second):
+		assert.Fail("initial insert didn't happened fast enough")
 
 	}
 
 	// Test insertTable() is NOT called again
 	// after all rows were rejected on first insert.
-	timer.Reset(1 * time.Second)
 	select {
 	case <-flushed:
-		t.Error("retry insert happened even though all rows were rejected")
-	case <-timer.C:
+		assert.Fail("retry insert happened even though all rows were rejected")
+	case <-time.After(1 * time.Second):
 	}
 
 	// Check that an error was logged for "all rows were rejected, moving on".
 	select {
 	case err, ok := <-s.Errors:
-		if !ok {
-			t.Fatal("Error channel is closed")
-		}
+		assert.True(ok, "Error channel is closed")
 		t.Log("Mocked errors (this is ok):", err)
 	default:
-		t.Errorf("Error \"all rows rejected\" is missing from error channel")
+		assert.Fail("Error \"all rows rejected\" is missing from error channel")
 	}
-
-	s.Stop()
 }
 
 // TestInsertAllLogErrors inserts 5 rows and mocks 3 response errors for 3 of these rows,
 // then tests whether these errors were forwarded to error channel.
 // This function is very similar in structure to TestInsertAll().
 func TestInsertAllLogErrors(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+
 	// Set a row threshold to 5 so it will flush immediately on calling Start().
 	s, err := NewStreamer(nil, 5, 1*time.Minute, 1*time.Second, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(err)
 
 	// Mock insertTable function to return mocked errors and notify table was mock "flushed".
 	// Will be used for testing errors were sent to error channel.
-	flushed := make(chan bool)
+	flushed := make(chan struct{})
 
 	insertCalled := false
 	s.insertTable = func(pId, dId, tId string, tt table) (r *bigquery.TableDataInsertAllResponse, err error) {
@@ -1158,7 +982,7 @@ func TestInsertAllLogErrors(t *testing.T) {
 		}
 
 		// Notify that this table was mock "flushed".
-		flushed <- true
+		flushed <- struct{}{}
 
 		insertCalled = true
 
@@ -1174,7 +998,6 @@ func TestInsertAllLogErrors(t *testing.T) {
 
 	// Start streamer and wait for flush to happen.
 	// Fail if flush takes too long.
-	timer := time.NewTimer(1 * time.Microsecond)
 	go s.Start()
 
 	// First loop is for initial insert (with error response).
@@ -1182,10 +1005,9 @@ func TestInsertAllLogErrors(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		select {
 		case <-flushed:
-		case <-timer.C:
-			t.Errorf("insert %d wasn't called fast enough", i)
+		case <-time.After(1 * time.Second):
+			assert.Fail(fmt.Sprintf("insert %d wasn't called fast enough", i))
 		}
-		timer.Reset(1 * time.Microsecond)
 	}
 
 	s.Stop()
@@ -1194,13 +1016,10 @@ func TestInsertAllLogErrors(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		select {
 		case err, ok := <-s.Errors:
-			if !ok {
-				t.Fatal("Error channel is closed")
-			}
-
+			assert.True(ok, "Error channel is closed")
 			t.Log("Mocked errors (this is ok):", err)
 		default:
-			t.Errorf("Error %d is missing from error channel", i)
+			require.Fail("Error %d is missing from error channel", i)
 		}
 	}
 }


### PR DESCRIPTION
- until now unit tests used the built-in "testing" package,
  testify makes tests much more concise. less code for great good!
- "stop" channel used to pass a meaningless boolean,
  no it passes an empty struct{}
- fixed some readme typos