### PR TITLE
Remove unsupported Go versions from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,13 @@ cache: apt
 language: go
 go:
   - tip
+  - 1.6.2
+  - 1.6.1
+  - 1.6  
   - 1.5.2
   - 1.5.1
   - 1.5
-  - 1.4.3
-  - 1.4.2
-  - 1.4.1
-  - 1.4
-  - 1.3.3
-  - 1.3.2
-  - 1.3.1
-  - 1.3
-
+  
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
And also add 1.6.x versions.

The Google API client doesn't support versions below 1.5.x anymore.