### PR TITLE
add SyncWorker.RowLen function that counts number of enqueued rows

### DIFF
--- a/async_worker.go
+++ b/async_worker.go
@@ -58,7 +58,7 @@ func (w *asyncWorker) Start() {
 				w.worker.Enqueue(r)
 
 				// Don't insert yet if not enough rows have been enqueued.
-				if len(w.worker.row) < w.maxRows {
+				if len(w.worker.rows) < w.maxRows {
 					continue
 				}
 
@@ -81,7 +81,7 @@ func (w *asyncWorker) Close() <-chan struct{} {
 // using the internal SyncWorker.
 func (w *asyncWorker) insert() {
 	// No-op if no lines have been enqueued.
-	if len(w.worker.row) == 0 {
+	if len(w.worker.rows) == 0 {
 		return
 	}
 

--- a/async_worker_test.go
+++ b/async_worker_test.go
@@ -123,8 +123,8 @@ func TestAsyncWorkerEnqueue(t *testing.T) {
 	// enqueued in the internal Worker row slice.
 	w.Start()
 	time.Sleep(100 * time.Millisecond)
-	require.Len(w.worker.row, 1)
-	require.Equal(NewRowWithID("p", "d", "t", "id0", map[string]bigquery.JsonValue{"k0": "v0"}), w.worker.row[0])
+	require.Len(w.worker.rows, 1)
+	require.Equal(NewRowWithID("p", "d", "t", "id0", map[string]bigquery.JsonValue{"k0": "v0"}), w.worker.rows[0])
 
 	// Enqueue four additional rows, and test they were "mock" inserted.
 	w.rowChan <- NewRowWithID("p", "d", "t", "id1", map[string]bigquery.JsonValue{"k1": "v1"})
@@ -132,7 +132,7 @@ func TestAsyncWorkerEnqueue(t *testing.T) {
 	w.rowChan <- NewRowWithID("p", "d", "t", "id3", map[string]bigquery.JsonValue{"k3": "v3"})
 	w.rowChan <- NewRowWithID("p", "d", "t", "id4", map[string]bigquery.JsonValue{"k4": "v4"})
 	time.Sleep(100 * time.Millisecond)
-	require.Len(w.worker.row, 5)
+	require.Len(w.worker.rows, 5)
 }
 
 // TestAsyncWorkerMaxDelay tests Worker executes an insert to BigQuery


### PR DESCRIPTION
- also renamed internal 'row' member to 'rows', should be plural
- this partially deals with #9, for SyncWorker, not for AsyncWorkerGroup